### PR TITLE
Set the response to json and get irectly the json response

### DIFF
--- a/src/core/ip.ts
+++ b/src/core/ip.ts
@@ -202,7 +202,7 @@ export function getLocationByIP(ip: string, callback: Function) {
                 callback(null);
             },
             success: (response) => {
-                const data = response.json();
+                const data = response;
                 const location = {
                     latitude: parseFloat(data.loc.split(',')[0]),
                     longitude: parseFloat(data.loc.split(',')[1]),
@@ -227,7 +227,7 @@ export function getUserIPAddress(callback: Function): void {
                 callback(null);
             },
             success: (response) => {
-                const data = response.json();
+                const data = response;
                 const ip = data.ip;
 
                 if (isValidIPv4(ip)) {


### PR DESCRIPTION

## Description
`response.json` is not valid because we have set response type to json before that.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify): ____________________

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please specify): ____________________